### PR TITLE
Update libjpeg-turbo to 2.1.90 (3.0 beta1) and fix bugs

### DIFF
--- a/extractor.c
+++ b/extractor.c
@@ -27,19 +27,22 @@ int getBMPFromJPEG(const uint8_t *input_data, size_t file_size,
                   BITMAPINFOHEADER *bitmap_info_header, uint8_t **data) {
 
 	int jpegSubsamp, width, height;
-	tjhandle jpegDecompressor = tjInitDecompress();
-	tjDecompressHeader2(jpegDecompressor, (uint8_t *)input_data, file_size, &width,
-	                    &height, &jpegSubsamp);
+	tjhandle jpegDecompressor = tj3Init(TJINIT_DECOMPRESS);
+	tj3DecompressHeader(jpegDecompressor, input_data, file_size);
+	width = tj3Get(jpegDecompressor, TJPARAM_JPEGWIDTH);
+	height = tj3Get(jpegDecompressor, TJPARAM_JPEGHEIGHT);
 
 	int bit_length = width * 4;
 
 	*data = malloc(bit_length * height);
-	if (!(*data))
+	if (!(*data)) {
+		tj3Destroy(jpegDecompressor);
 		return -1;
+	}
 
-	tjDecompress2(jpegDecompressor, input_data, file_size, *data, width,
-	              bit_length, height, TJPF_RGBA, TJFLAG_ACCURATEDCT);
-	tjDestroy(jpegDecompressor);
+	tj3Set(jpegDecompressor, TJPARAM_BOTTOMUP, 1);
+	tj3Decompress8(jpegDecompressor, input_data, file_size, *data, bit_length, TJPF_BGRA);
+	tj3Destroy(jpegDecompressor);
 
 	memset(bitmap_file_header, 0, sizeof(BITMAPFILEHEADER));
 	memset(bitmap_info_header, 0, sizeof(BITMAPINFOHEADER));
@@ -68,8 +71,7 @@ int getBMPFromJPEG(const uint8_t *input_data, size_t file_size,
 }
 
 BOOL IsSupportedEx(const char *data) {
-	if (!memcmp(data, "\xFF\xD8\xFF", 3) && data[3] >= 0xE0 &&
-	    data[3] <= 0xEF) {
+	if (!memcmp(data, "\xFF\xD8\xFF", 3)) {
 		return TRUE;
 	}
 	return FALSE;
@@ -107,7 +109,7 @@ int GetPictureEx(size_t data_size, HANDLE *bitmap_info, HANDLE *bitmap_data,
 		if (progress_callback(1, 1, user_data))
 			return SPI_ABORT;
 
-	if (!getBMPFromJPEG((const uint8_t *)data, data_size, &bitmap_file_header,
+	if (getBMPFromJPEG((const uint8_t *)data, data_size, &bitmap_file_header,
 	                   &bitmap_info_header, &data_u8))
 		return SPI_MEMORY_ERROR;
 	*bitmap_info = LocalAlloc(LMEM_MOVEABLE, sizeof(BITMAPINFOHEADER));


### PR DESCRIPTION
1. Fixed bugs that were fundamentally not working properly.
2. Use libjpeg-turbo 2.1.90 (3.0 beta1) functionality to retrieve bottom-up image.